### PR TITLE
Move Contour service to dedicated contour namespace

### DIFF
--- a/contour/release.yaml
+++ b/contour/release.yaml
@@ -2,6 +2,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
     name: contour
+    namespace: contour
 spec:
     releaseName: contour
     chart:


### PR DESCRIPTION
Contour is currently deployed to the `default` namespace, although there is a dedicated `contour` namespace created in `contour/namespace.yaml`.

Changes:
* Move contour from `default` to `contour` namespace.